### PR TITLE
Added readline support where possible

### DIFF
--- a/repl.py
+++ b/repl.py
@@ -5,6 +5,21 @@ from parser import lispparser
 from core import evaluate, tostring, Scope
 import re
 
+try:
+    import readline
+except ImportError:
+    pass
+else:
+    import os
+    histfile = os.path.join(os.path.expanduser("~"), ".pyclojurehist")
+    try:
+        readline.read_history_file(histfile)
+    except IOError:
+        # Pass here as there isn't any history file, so one will be
+        # written by atexit
+        pass
+    import atexit
+    atexit.register(readline.write_history_file, histfile)
 
 parse = lispparser()
 lexer = lisplexer()


### PR DESCRIPTION
This allows the use of arrow navigation through history, and persistant history
that will be stored in the $HOME/.pyclojurehist file.

Not all systems come with readline support, so we wrap the import readline with a try.
