### PR TITLE
Adding fallback to importing setup() from distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 from os.path import exists
-from setuptools import setup
+try:
+    # Use setup() from setuptools(/distribute) if available
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 from pyclojure import __version__
 
 setup(


### PR DESCRIPTION
`distutils` is always available, whereas setuptools/distribute are optional extras but have added functionality.
