### PR TITLE
Reader macro support

### DIFF
--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -95,10 +95,10 @@ class GlobalScope(Scope):
     def __init__(self, *args, **kwargs):
         Scope.__init__(self, *args, **kwargs)
         # Get all builtin python functions
-        python_functions = [(name, PythonFunction(obj)) for name, obj\
+        python_callables = [(name, PythonFunction(obj)) for name, obj\
                                 in __builtins__.items() if\
-                                type(abs) == type(obj)]
-        self.update(python_functions)
+                                callable(obj)]
+        self.update(python_callables)
 
         # These functions take a variable number of arguments
         variadic_operators = {'+': ('add', 0),

--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -210,7 +210,7 @@ def eval_list(contents, scopes):
         else:
             val = find_in_scopechain(scopes, name)
             if not val:
-                raise UnknownVariable("Function %s is unknown")
+                raise UnknownVariable("Function %s is unknown" % name)
             if callable(val):
                 args = map((lambda obj: evaluate(obj, scopes)), rest)
                 return val(*args)

--- a/pyclojure/lexer.py
+++ b/pyclojure/lexer.py
@@ -42,7 +42,7 @@ class PyClojureLex(object):
         return t
 
     def t_READMACRO(self, t):
-        r'[@\'#^`\\][\*\+\!\-\_a-zA-Z_-]+'
+        r'[@\'#^`\\.][\*\+\!\-\_a-zA-Z_-]+'
         # Just the standard atom regex will all the possible reader
         # chars prepended to it.
         return t

--- a/pyclojure/lexer.py
+++ b/pyclojure/lexer.py
@@ -8,7 +8,7 @@ class PyClojureLex(object):
     reserved = {'nil': 'NIL'}
 
     tokens = ['ATOM', 'KEYWORD',
-              'NUMBER',
+              'NUMBER', 'READMACRO',
               'LBRACKET', 'RBRACKET',
               'LBRACE', 'RBRACE',
               'LPAREN', 'RPAREN'] + list(reserved.values())
@@ -39,6 +39,12 @@ class PyClojureLex(object):
     def t_ATOM(self, t):
         r'[\*\+\!\-\_a-zA-Z_-]+'
         t.type = self.reserved.get(t.value, 'ATOM')
+        return t
+
+    def t_READMACRO(self, t):
+        r'[@\'#^`\\][\*\+\!\-\_a-zA-Z_-]+'
+        # Just the standard atom regex will all the possible reader
+        # chars prepended to it.
         return t
 
     def t_newline(self, t):

--- a/pyclojure/lexer.py
+++ b/pyclojure/lexer.py
@@ -42,9 +42,8 @@ class PyClojureLex(object):
         return t
 
     def t_READMACRO(self, t):
-        r'[@\'#^`\\.][\*\+\!\-\_a-zA-Z_-]+'
-        # Just the standard atom regex will all the possible reader
-        # chars prepended to it.
+        r'[@\'#^`\\.]+'
+        # All the possible reader macro chars
         return t
 
     def t_newline(self, t):

--- a/pyclojure/parser.py
+++ b/pyclojure/parser.py
@@ -39,11 +39,17 @@ def quote_atom(raw):
 def deref_atom(raw):
     return List(Atom('deref'), Atom(raw[1:]))
 
+def init_type(raw):
+    # Due to how python types are initialized, we can just treat them
+    # as function calls.
+    return Atom(raw[1:])
+
 # Map from the regex that matches the atom to the function that takes
 # in a string and returns the correct ast
 READER_MACROS = {
     r'^@.*': deref_atom,
     r'^\'.*': quote_atom,
+    r'^\..*': init_type,
     }
 
 class PyClojureParse(object):

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -34,6 +34,7 @@ def test_reader_macros():
     assert parse("@a") == parse("(deref a)")
     assert parse("'a") == parse("(quote a)")
     assert parse("(.float 3)") == parse("(float 3)")
+    assert parse("'(1 2 3)") == parse("(quote (1 2 3))")
 
 
 def test_core():

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -29,6 +29,12 @@ def test_parser():
     assert parse('()') == List()
 
 
+def test_reader_macros():
+    parse = PyClojureParse().build().parse
+    assert parse("@a") == parse("(deref a)")
+    assert parse("'a") == parse("(quote a)")
+
+
 def test_core():
     Atom()
     Atom('a')

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -33,6 +33,7 @@ def test_reader_macros():
     parse = PyClojureParse().build().parse
     assert parse("@a") == parse("(deref a)")
     assert parse("'a") == parse("(quote a)")
+    assert parse("(.float 3)") == parse("(float 3)")
 
 
 def test_core():
@@ -146,6 +147,7 @@ def test_float_parsing():
     assert evalparse("0.12E2") == 12
     assert evalparse("-0.12E+02") == -12
     assert evalparse("-0.12E-2") == -.0012
+    assert evalparse("(.float 3)") == 3.0
 
 
 def test_to_string():


### PR DESCRIPTION
Added support for reader macros such as `'a` and `@a`, along with python type initialization in the form `(.float 3)`.

Also extracted the evaluation of lists in the evaluate function into a seperate eval_list function. Built in functions can now be defined simply as functions with the `register_builtin` decorator.
