### PR TITLE
Patch for Issue 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ parsetab.py
 .project
 .pydevproject
 parser.out
+build
+dist
+*.egg-info

--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -1,4 +1,5 @@
 import operator
+from funktown import ImmutableDict, ImmutableVector
 
 
 class ComparableExpr(object):
@@ -10,9 +11,9 @@ class ComparableExpr(object):
 class Map(ComparableExpr):
     def __init__(self, *args, **kwargs):
         if len(args) == 1 and not kwargs:
-            self.__dict = args[0]
+            self.__dict = ImmutableDict(args[0])
         else:
-            self.__dict = kwargs
+            self.__dict = ImmutableDict(kwargs)
 
     def __getitem__(self, name):
         return self.__dict[name]
@@ -61,8 +62,16 @@ class List(ComparableList):
     pass
 
 
-class Vector(ComparableList):
-    pass
+class Vector(ComparableExpr):
+    def __init__(self, *args):
+        self.__contents = ImmutableVector(args)
+
+    def contents(self):
+        return self.__contents
+
+    def __repr__(self):
+        return "%s(%s)" % (self,__class__.__name__.upper(),
+                           ','.join([str(el) for el in self.__contents]))
 
 
 class Keyword(ComparableExpr):

--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -18,9 +18,6 @@ class Map(ComparableExpr):
     def __getitem__(self, name):
         return self.__dict[name]
 
-    def __setitem__(self, name, value):
-        self.__dict[name] = value
-
     def __repr__(self):
         return 'MAP(%s)' % (self.__dict)
 
@@ -44,7 +41,7 @@ class Atom(ComparableExpr):
         return "ATOM(%s)" % (self.__name)
 
 
-class ComparableList(ComparableExpr):
+class List(ComparableExpr):
     def __init__(self, *args):
         self.__contents = []
         for arg in args:
@@ -56,10 +53,6 @@ class ComparableList(ComparableExpr):
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__.upper(),
                            ','.join([str(el) for el in self.__contents]))
-
-
-class List(ComparableList):
-    pass
 
 
 class Vector(ComparableExpr):

--- a/pyclojure/parser.py
+++ b/pyclojure/parser.py
@@ -25,11 +25,11 @@ class LispLogger(yacc.PlyLogger):
             super(type(self), self).debug(*args, **kwargs)
 
 def make_map(args):
-    m = Map()
+    m = {}
     kvlist = [(args[i], args[i+1]) for i in range(0, len(args), 2)]
     for k, v in kvlist:
         m[k] = v
-    return m
+    return Map(m)
 
 class PyClojureParse(object):
     def build(self):

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -62,7 +62,6 @@ def test_core():
     assert Map(x=1) != Map(x=2)
     assert Map(x=1) != Map(x=1, a=3)
     assert Map(x=1)["x"] == 1
-    Map()["1"] = 2
 
 
 def evalparser():
@@ -81,10 +80,9 @@ def test_eval():
     assert evalparse("[]") == Vector()
     assert evalparse("[1 2 3]") == Vector(1, 2, 3)
     assert evalparse("{}") == Map()
-    m = Map()
-    m[1] = 2
+    m = Map({1:2})
     assert evalparse("{1 2}") == m
-    m[3] = 4
+    m = Map({1:2, 3:4})
     assert evalparse("{1 2, 3 4}") == m
 
     try:

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(
     entry_points=dict(console_scripts=['pyclojure=pyclojure.repl:main']),
     install_requires=[
         'ply>=3.4',
+        'funktown>=0.3.0'
     ],
 )


### PR DESCRIPTION
These commits switch to using immutable vectors and maps from the [funktown](http://github.com/zhemao/funktown) library. Right now, the Vector and Map classes have to wrap ImmutableVector and ImmutableMap from funktown because the interfaces are slightly different. I hope to eventually get it so that PyClojure can use the funktown datastructures directly.
