### PR TITLE
Make python compatablity much easier by letting PyClojure inherit python native objects.

### DIFF
--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -48,8 +48,6 @@ class Atom(ComparableExpr):
 
 class ComparableIter(ComparableExpr):
     def __eq__(self, other):
-        # FIXME: This one is... interesting when called on infinite
-        # generators
         try:
             if len(self) != len(other):
                 return False

--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -7,6 +7,8 @@ class ComparableExpr(object):
         return (isinstance(other, self.__class__)
                 and self.__dict__ == other.__dict__)
 
+    def __ne__(self, other):
+        return not (self == other)
 
 class Map(ComparableExpr):
     def __init__(self, *args, **kwargs):

--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -10,27 +10,28 @@ class ComparableExpr(object):
     def __ne__(self, other):
         return not (self == other)
 
-class Map(ComparableExpr):
+
+class Map(ComparableExpr, ImmutableDict):
     def __init__(self, *args, **kwargs):
         if len(args) == 1 and not kwargs:
-            self.__dict = ImmutableDict(args[0])
+            ImmutableDict.__init__(self, args[0])
         else:
-            self.__dict = ImmutableDict(kwargs)
+            ImmutableDict.__init__(self, kwargs)
 
-    def __getitem__(self, name):
-        return self.__dict[name]
+    def __eq__(self, other):
+        if type(other) is not Map:
+            return False
+        my_keys = sorted(self.keys())
+        their_keys = sorted(other.keys())
+        for mine, theirs in zip(my_keys, their_keys):
+            if mine != theirs:
+                return False
+            if self[mine] != other[theirs]:
+                return False
+        return True
 
     def __repr__(self):
-        return 'MAP(%s)' % (self.__dict)
-
-    def items(self):
-        return self.__dict.items()
-
-    def keys(self):
-        return self.__dict.keys()
-
-    def values(self):
-        return self.__dict.values()
+        return 'MAP(%s)' % (dict(self))
 
 class Atom(ComparableExpr):
     def __init__(self, name=None, value=None):

--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -63,7 +63,7 @@ class Vector(ComparableExpr):
         return self.__contents
 
     def __repr__(self):
-        return "%s(%s)" % (self,__class__.__name__.upper(),
+        return "%s(%s)" % (self.__class__.__name__.upper(),
                            ','.join([str(el) for el in self.__contents]))
 
 

--- a/pyclojure/core.py
+++ b/pyclojure/core.py
@@ -19,16 +19,18 @@ class Map(ComparableExpr, ImmutableDict):
             ImmutableDict.__init__(self, kwargs)
 
     def __eq__(self, other):
-        if type(other) is not Map:
+        try:
+            my_keys = sorted(self.keys())
+            their_keys = sorted(other.keys())
+            for mine, theirs in zip(my_keys, their_keys):
+                if mine != theirs:
+                    return False
+                if self[mine] != other[theirs]:
+                    return False
+        except:
             return False
-        my_keys = sorted(self.keys())
-        their_keys = sorted(other.keys())
-        for mine, theirs in zip(my_keys, their_keys):
-            if mine != theirs:
-                return False
-            if self[mine] != other[theirs]:
-                return False
-        return True
+        else:
+            return True
 
     def __repr__(self):
         return 'MAP(%s)' % (dict(self))
@@ -46,15 +48,18 @@ class Atom(ComparableExpr):
 
 class ComparableIter(ComparableExpr):
     def __eq__(self, other):
-        # FIXME: This one is... interesting when called on infinite generators
-        if not issubclass(type(other), ComparableIter):
-            return False
-        if len(self) != len(other):
-            return False
-        for a, b in zip(self, other):
-            if a != b:
+        # FIXME: This one is... interesting when called on infinite
+        # generators
+        try:
+            if len(self) != len(other):
                 return False
-        return True
+            for a, b in zip(self, other):
+                if a != b:
+                    return False
+        except:
+            return False
+        else:
+            return True
 
 
 class List(ComparableIter, list):

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -143,11 +143,18 @@ def test_eval():
 
 def test_function_calling():
     '''
-    Test builtin python function calling
+    Test builtin function calling
     '''
     evalparse = evalparser()
     assert evalparse("(abs (- 0 100))") == 100
     assert evalparse("(round 3.3)") == 3.0
+    evalparse("(def a 3)")
+    assert evalparse("a") == 3
+    try:
+        evalparse("(def a 3 2)")
+        assert False, "TypeError expected"
+    except TypeError:
+        pass
 
 
 def test_float_parsing():

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -155,7 +155,11 @@ def test_function_calling():
         assert False, "TypeError expected"
     except TypeError:
         pass
-
+    try:
+        evalparse("(def 3 a)")
+        assert False, "TypeError expected"
+    except TypeError:
+        pass
 
 def test_float_parsing():
     '''

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -72,6 +72,14 @@ def test_core():
     assert Map(x=1)["x"] == 1
 
 
+def test_python_compat():
+    assert List(1, 2, 3) == [1, 2, 3]
+    assert Map() == {}
+    assert Map(a=3) == {'a': 3}
+    assert Vector(*range(10)) == range(10)
+    assert map(abs, List(-1, -2, -3)) == List(1, 2, 3)
+
+
 def evalparser():
     parse = PyClojureParse().build().parse
     scopechain = [GlobalScope()]

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -76,8 +76,16 @@ def test_python_compat():
     assert List(1, 2, 3) == [1, 2, 3]
     assert Map() == {}
     assert Map(a=3) == {'a': 3}
+    assert Map(a=3) != ['a', 3]
     assert Vector(*range(10)) == range(10)
     assert map(abs, List(-1, -2, -3)) == List(1, 2, 3)
+    def infinite_gen():
+        x = 1
+        while 1:
+            x += 1
+            yield x
+    assert List(1, 2, 3) != infinite_gen()
+    assert List(1, 2) != List(1, 2, 3)
 
 
 def evalparser():

--- a/pyclojure/test_lisp.py
+++ b/pyclojure/test_lisp.py
@@ -60,7 +60,7 @@ def test_core():
     assert List(Atom('b')) != List(Atom('a'))
     assert Vector(1, 2) != Vector(2, 1)
     assert Vector(1, 2) == Vector(1, 2)
-    assert Vector(1, 2) != List(1, 2)
+    assert Vector(1, 2) == List(1, 2)
     assert Keyword("a") == Keyword("a")
     assert Keyword("a") != Keyword("b")
     Map()


### PR DESCRIPTION
By subclassing raw objects things like iteration become much easier. Calling `(map round [1.0 2.3 4.3])` will now work because the vector class inherits from the ImmutableVector class which is an iterator that map will accept.

I also added a new ComparableIter class to allow comparison between PyClojure lists and vectors, python lists, and 3rd party iterables. The addition of the `__ne__` method to ComparableExpr was because `Atom() != Atom()` was the same as `Atom() == Atom()`, which wasn't correct.

Also added some new tests. I used the coverage plugin to test the coverage and core is at 94%, with the majority of untested methods being `__repr__` or something similar.
